### PR TITLE
cxdb/cxdbsql: add struct creation, typos, tests

### DIFF
--- a/cmd/opencxd/opencxd.go
+++ b/cmd/opencxd/opencxd.go
@@ -119,6 +119,7 @@ func main() {
 		logging.Fatalf("Could not generate asset pairs from coin list: %s", err)
 	}
 
+	logging.Infof("Creating limit engines...")
 	var mengines map[match.Pair]match.LimitEngine
 	if mengines, err = cxdbsql.CreateLimitEngineMap(pairList); err != nil {
 		logging.Fatalf("Error creating limit engine map with coinlist for opencxd: %s", err)
@@ -142,10 +143,12 @@ func main() {
 		for _, coin := range coinList {
 			whitelistMap[coin] = whitelist
 		}
+		logging.Infof("Creating pinky swear engines...")
 		if setEngines, err = cxdbmemory.CreatePinkySwearEngineMap(whitelistMap, true); err != nil {
 			logging.Fatalf("Error creating pinky swear settlement engine map for opencxd: %s", err)
 		}
 	} else {
+		logging.Infof("Creating settlement engines...")
 		if setEngines, err = cxdbsql.CreateSettlementEngineMap(coinList); err != nil {
 			logging.Fatalf("Error creating settlement engine map for opencxd: %s", err)
 		}
@@ -154,16 +157,19 @@ func main() {
 		logging.Fatalf("Error, nil setEngines map, this should not ever happen")
 	}
 
+	logging.Infof("Creating limit orderbooks...")
 	var limBooks map[match.Pair]match.LimitOrderbook
 	if limBooks, err = cxdbsql.CreateLimitOrderbookMap(pairList); err != nil {
 		logging.Fatalf("Error creating limit orderbook map for opencxd: %s", err)
 	}
 
+	logging.Infof("Creating deposit stores...")
 	var depositStores map[*coinparam.Params]cxdb.DepositStore
 	if depositStores, err = cxdbsql.CreateDepositStoreMap(coinList); err != nil {
 		logging.Fatalf("Error creating deposit store map for opencxd: %s", err)
 	}
 
+	logging.Infof("Creating settlement stores...")
 	var setStores map[*coinparam.Params]cxdb.SettlementStore
 	if setStores, err = cxdbsql.CreateSettlementStoreMap(coinList); err != nil {
 		logging.Fatalf("Error creating settlement store map for opencxd: %s", err)

--- a/cxdb/cxdbsql/dbconfig.go
+++ b/cxdb/cxdbsql/dbconfig.go
@@ -118,7 +118,7 @@ func createDefaultConfigFile(destinationPath string) error {
 	defer dest.Close()
 
 	writer := bufio.NewWriter(dest)
-	defaultArgs := []byte("\n")
+	defaultArgs := []byte("dbuser=opencx\ndbpassword=testpass\n")
 	_, err = writer.Write(defaultArgs)
 	if err != nil {
 		return err

--- a/cxdb/cxdbsql/depositstore_test.go
+++ b/cxdb/cxdbsql/depositstore_test.go
@@ -1,0 +1,33 @@
+package cxdbsql
+
+import (
+	"testing"
+)
+
+func TestCreateDepositStoreAllParams(t *testing.T) {
+	var err error
+
+	var tc *testerContainer
+	if tc, err = CreateTesterContainer(); err != nil {
+		t.Errorf("Error creating tester container: %s", err)
+	}
+
+	defer func() {
+		if err = tc.Kill(); err != nil {
+			t.Errorf("Error killing tester container: %s", err)
+			return
+		}
+	}()
+
+	var ds *SQLDepositStore
+	for _, coin := range constCoinParams() {
+		if ds, err = CreateDepositStoreStructWithConf(coin, testConfig()); err != nil {
+			t.Errorf("Error creating deposit store for coin: %s", err)
+		}
+
+		if err = ds.DestroyHandler(); err != nil {
+			t.Errorf("Error destroying handler for deposit store: %s", err)
+		}
+	}
+
+}

--- a/cxdb/cxdbsql/limitengine.go
+++ b/cxdb/cxdbsql/limitengine.go
@@ -73,7 +73,7 @@ func CreateLimEngineStructWithConf(pair *match.Pair, conf *dbsqlConfig) (engine 
 
 	// Make sure we can actually connect
 	if err = le.DBHandler.Ping(); err != nil {
-		err = fmt.Errorf("Could not ping the database, is it running: %s", err)
+		err = fmt.Errorf("Could not ping the database, is it running? Did you set the username and password in sqldb.conf: %s", err)
 		return
 	}
 


### PR DESCRIPTION
This fixes #33, and adds a test for DepositStore creation so similar changes that break creation of DepositStores can be caught.

Adds additional info-level logging on startup.