### PR TITLE
match: add protocol verify test and benchmarks

### DIFF
--- a/crypto/rsw/rswtimelock.go
+++ b/crypto/rsw/rswtimelock.go
@@ -323,7 +323,7 @@ func (pz *PuzzleRSW) Serialize() (raw []byte, err error) {
 	return
 }
 
-// Deserialize turns the RSW puzzle into something that can be sent over the wire
+// Deserialize turns a gob-encoded puzzle into a go struct we can use.
 func (pz *PuzzleRSW) Deserialize(raw []byte) (err error) {
 	var b *bytes.Buffer
 	b = bytes.NewBuffer(raw)

--- a/crypto/rsw/rswtimelock.go
+++ b/crypto/rsw/rswtimelock.go
@@ -260,6 +260,7 @@ func (pz *PuzzleRSW) SolveCkXOR() (answer []byte, err error) {
 	} else {
 		answer = make([]byte, len(ansBytes))
 	}
+	copy(answer, ansBytes)
 	return
 }
 

--- a/crypto/rsw/rswtimelock.go
+++ b/crypto/rsw/rswtimelock.go
@@ -67,9 +67,44 @@ func New2048(key []byte, a int64) (tl crypto.Timelock, err error) {
 	return New(key, a, 2048)
 }
 
-//New2048A2 is the same as New2048 but we use a base of 2. It's called A2 because A=2 I guess
+// New2048A2 is the same as New2048 but we use a base of 2. It's called A2 because A=2 I guess
 func New2048A2(key []byte) (tl crypto.Timelock, err error) {
 	return New(key, 2, 2048)
+}
+
+// NewTimelockWithPrimes creates a new timelock puzzle with primes p
+// and q.
+func NewTimelockWithPrimes(key []byte, a int64, p *big.Int, q *big.Int) (timelock crypto.Timelock, err error) {
+	if p == nil {
+		err = fmt.Errorf("p pointer cannot be nil, please investigate")
+		return
+	}
+	if q == nil {
+		err = fmt.Errorf("q pointer cannot be nil, please investigate")
+		return
+	}
+	tl := new(TimelockRSW)
+
+	// Create a temporary N = p * q and set the bit length
+	tempN := new(big.Int)
+	tempN.Mul(p, q)
+	tl.rsaKeyBits = tempN.BitLen()
+
+	// now set the p and q values
+	tl.p = new(big.Int)
+	tl.q = new(big.Int)
+	tl.p.Set(p)
+	tl.q.Set(q)
+
+	// Set the a value
+	tl.a = big.NewInt(a)
+
+	// copy over the key
+	tl.key = make([]byte, len(key))
+	copy(tl.key, key)
+
+	timelock = tl
+	return
 }
 
 func (tl *TimelockRSW) n() (n *big.Int, err error) {

--- a/crypto/rsw/rswtimelock.go
+++ b/crypto/rsw/rswtimelock.go
@@ -74,7 +74,7 @@ func New2048A2(key []byte) (tl crypto.Timelock, err error) {
 
 // NewTimelockWithPrimes creates a new timelock puzzle with primes p
 // and q.
-func NewTimelockWithPrimes(key []byte, a int64, p *big.Int, q *big.Int) (timelock crypto.Timelock, err error) {
+func NewTimelockWithPrimes(key []byte, a uint64, p *big.Int, q *big.Int) (timelock crypto.Timelock, err error) {
 	if p == nil {
 		err = fmt.Errorf("p pointer cannot be nil, please investigate")
 		return
@@ -84,6 +84,7 @@ func NewTimelockWithPrimes(key []byte, a int64, p *big.Int, q *big.Int) (timeloc
 		return
 	}
 	tl := new(TimelockRSW)
+	aInt := int64(a)
 
 	// Create a temporary N = p * q and set the bit length
 	tempN := new(big.Int)
@@ -97,7 +98,7 @@ func NewTimelockWithPrimes(key []byte, a int64, p *big.Int, q *big.Int) (timeloc
 	tl.q.Set(q)
 
 	// Set the a value
-	tl.a = big.NewInt(a)
+	tl.a = big.NewInt(aInt)
 
 	// copy over the key
 	tl.key = make([]byte, len(key))

--- a/crypto/rsw/timelockverify.go
+++ b/crypto/rsw/timelockverify.go
@@ -1,0 +1,56 @@
+package rsw
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+)
+
+// VerifyPuzzleOutput verifies that the timelock puzzle PuzzleRSW
+func VerifyPuzzleOutput(p *big.Int, q *big.Int, pz *PuzzleRSW, claimedKey []byte) (valid bool, err error) {
+	if p == nil {
+		err = fmt.Errorf("p pointer cannot be nil, please investigate")
+		return
+	}
+	if q == nil {
+		err = fmt.Errorf("q pointer cannot be nil, please investigate")
+		return
+	}
+
+	tempN := new(big.Int)
+	tempN.Mul(p, q)
+	if tempN.Cmp(pz.N) != 0 {
+		err = fmt.Errorf("The p and q given do not multiply to the puzzle modulus")
+		return
+	}
+
+	// compute trapdoor
+	// phi(n) = (p-1)(q-1). We assume p and q are prime, and n = pq.
+	phi := new(big.Int).Mul(new(big.Int).Sub(p, big.NewInt(1)), new(big.Int).Sub(q, big.NewInt(1)))
+
+	// e = 2^t mod phi()
+	e := new(big.Int).Exp(big.NewInt(2), pz.T, phi)
+
+	// b = a^(e()) (mod n())
+	b := new(big.Int).Exp(pz.A, e, pz.N)
+
+	// now xor with ck, getting the bytes
+	// if this is xor then the ck, err = blah like needs to be xor as well
+	var answer []byte
+	xorBytes := new(big.Int).Xor(pz.CK, b).Bytes()
+	if len(xorBytes) <= 16 {
+		answerBacking := [16]byte{}
+		answer = answerBacking[:]
+	} else {
+		answer = make([]byte, len(xorBytes))
+	}
+	copy(answer, xorBytes)
+
+	if res := bytes.Compare(answer, claimedKey); res != 0 {
+		err = fmt.Errorf("The claimed key:\n\t%x\nIs not equal to the puzzle solution:\n\t%x\nSo the claimed solution is invalid", claimedKey, answer)
+		return
+	}
+
+	valid = true
+	return
+}

--- a/crypto/timelockencoders/blockciphers.go
+++ b/crypto/timelockencoders/blockciphers.go
@@ -204,6 +204,16 @@ func SolvePuzzleRC5(ciphertext []byte, puzzle crypto.Puzzle) (message []byte, er
 		return
 	}
 
+	if message, err = DecryptPuzzleRC5(ciphertext, key); err != nil {
+		err = fmt.Errorf("Error decrypting puzzle after solving: %s", err)
+		return
+	}
+
+	return
+}
+
+// DecryptPuzzleRC5 decrypts the ciphertext using RC5
+func DecryptPuzzleRC5(ciphertext []byte, key []byte) (message []byte, err error) {
 	var RC5Cipher cipher.Block
 	if RC5Cipher, err = rc5.New(key); err != nil {
 		err = fmt.Errorf("Could not create new rc5 cipher for puzzle: %s", err)

--- a/crypto/timelockencoders/blockciphers.go
+++ b/crypto/timelockencoders/blockciphers.go
@@ -68,8 +68,8 @@ func createRSWPuzzleWithPrimes(a uint64, t uint64, key []byte, p *big.Int, q *bi
 
 // CreateRC5RSWPuzzleWithPrimes creates a RSW timelock puzzle with
 // time t and encrypts the message using RC5, given some user-defined
-// primes.
-func CreateRC5RSWPuzzleWithPrimes(a uint64, t uint64, message []byte, p *big.Int, q *big.Int) (ciphertext []byte, puzzle crypto.Puzzle, err error) {
+// primes. This returns a struct unlike the other methods here.
+func CreateRC5RSWPuzzleWithPrimes(a uint64, t uint64, message []byte, p *big.Int, q *big.Int) (ciphertext []byte, puzzle rsw.PuzzleRSW, err error) {
 	// Generate private key
 	var key []byte
 	if key, err = Generate16ByteKey(rand.Reader); err != nil {
@@ -77,8 +77,20 @@ func CreateRC5RSWPuzzleWithPrimes(a uint64, t uint64, message []byte, p *big.Int
 		return
 	}
 
-	if puzzle, key, err = createRSWPuzzleWithPrimes(a, t, key, p, q); err != nil {
+	var pzInterface crypto.Puzzle
+	if pzInterface, key, err = createRSWPuzzleWithPrimes(a, t, key, p, q); err != nil {
 		err = fmt.Errorf("Error creating rsw puzzle with primes before encrypting: %s", err)
+		return
+	}
+
+	var pzSerialized []byte
+	if pzSerialized, err = pzInterface.Serialize(); err != nil {
+		err = fmt.Errorf("Error serializing puzzle before encryption: %s", err)
+		return
+	}
+
+	if err = puzzle.Deserialize(pzSerialized); err != nil {
+		err = fmt.Errorf("Error deserializing puzzle before encryption: %s", err)
 		return
 	}
 

--- a/match/auctionorder.go
+++ b/match/auctionorder.go
@@ -27,7 +27,7 @@ type AuctionOrder struct {
 	AmountWant uint64 `json:"amountwant"`
 	// IntendedAuction as the auctionID this should be in. We need this to protect against
 	// the exchange withholding an order.
-	AuctionID [32]byte `json:"auctionid"`
+	AuctionID AuctionID `json:"auctionid"`
 	// 2 byte nonce (So there can be max 2^16 of the same-looking orders by the same pubkey in the same batch)
 	// This is used to protect against the exchange trying to replay a bunch of orders
 	Nonce     [2]byte `json:"nonce"`

--- a/match/commitresponse.go
+++ b/match/commitresponse.go
@@ -1,0 +1,56 @@
+package match
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+)
+
+// CommitResponse is the commitment response. The sig is the
+// puzzleanswerreveal + the commitment + the commitsig
+type CommitResponse struct {
+	CommResponseSig    [65]byte      `json:"commresponse"`
+	PuzzleAnswerReveal SolutionOrder `json:"puzzleanswer"`
+}
+
+// Serialize uses gob encoding to turn the commit response into bytes.
+func (cr *CommitResponse) Serialize() (raw []byte, err error) {
+	var b bytes.Buffer
+
+	// register commit response interface
+	gob.Register(CommitResponse{})
+
+	// create a new encoder writing to the buffer
+	enc := gob.NewEncoder(&b)
+
+	// encode the commit response in the buffer
+	if err = enc.Encode(cr); err != nil {
+		err = fmt.Errorf("Error encoding commit response: %s", err)
+		return
+	}
+
+	// Get the bytes from the buffer
+	raw = b.Bytes()
+	return
+}
+
+// Deserialize turns the commit response from bytes into a usable
+// struct.
+func (cr *CommitResponse) Deserialize(raw []byte) (err error) {
+	var b *bytes.Buffer
+	b = bytes.NewBuffer(raw)
+
+	// register CommitResponse
+	gob.Register(CommitResponse{})
+
+	// create a new decoder writing to the buffer
+	dec := gob.NewDecoder(b)
+
+	// decode the commit response in the buffer
+	if err = dec.Decode(cr); err != nil {
+		err = fmt.Errorf("Error decoding commitresponse: %s", err)
+		return
+	}
+
+	return
+}

--- a/match/encryptedauctionorder.go
+++ b/match/encryptedauctionorder.go
@@ -15,7 +15,7 @@ import (
 type EncryptedAuctionOrder struct {
 	OrderCiphertext []byte
 	OrderPuzzle     crypto.Puzzle
-	IntendedAuction [32]byte
+	IntendedAuction AuctionID
 	IntendedPair    Pair
 }
 

--- a/match/encsolorder.go
+++ b/match/encsolorder.go
@@ -1,0 +1,61 @@
+package match
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+
+	"github.com/mit-dci/opencx/crypto/rsw"
+)
+
+// EncryptedSolutionOrder represents an encrypted Solution Order, so a
+// ciphertext and a puzzle solution that is a key, and an intended auction.
+type EncryptedSolutionOrder struct {
+	OrderCiphertext []byte        `json:"orderciphertext"`
+	OrderPuzzle     rsw.PuzzleRSW `json:"orderpuzzle"`
+	IntendedAuction AuctionID     `json:"intendedauction"`
+	IntendedPair    Pair          `json:"intendedpair"`
+}
+
+// Serialize uses gob encoding to turn the encrypted solution order
+// into bytes.
+func (es *EncryptedSolutionOrder) Serialize() (raw []byte, err error) {
+	var b bytes.Buffer
+
+	// register SolutionOrder interface
+	gob.Register(EncryptedSolutionOrder{})
+
+	// create a new encoder writing to the buffer
+	enc := gob.NewEncoder(&b)
+
+	// encode the puzzle in the buffer
+	if err = enc.Encode(es); err != nil {
+		err = fmt.Errorf("Error encoding encryptedsolutionorder: %s", err)
+		return
+	}
+
+	// Get the bytes from the buffer
+	raw = b.Bytes()
+	return
+}
+
+// Deserialize turns the encrypted solution order from bytes into a
+// usable struct.
+func (es *EncryptedSolutionOrder) Deserialize(raw []byte) (err error) {
+	var b *bytes.Buffer
+	b = bytes.NewBuffer(raw)
+
+	// register SolutionOrder
+	gob.Register(EncryptedSolutionOrder{})
+
+	// create a new decoder writing to the buffer
+	dec := gob.NewDecoder(b)
+
+	// decode the solutionorder in the buffer
+	if err = dec.Decode(es); err != nil {
+		err = fmt.Errorf("Error decoding encryptedsolutionorder: %s", err)
+		return
+	}
+
+	return
+}

--- a/match/encsolorder.go
+++ b/match/encsolorder.go
@@ -17,6 +17,12 @@ type EncryptedSolutionOrder struct {
 	IntendedPair    Pair          `json:"intendedpair"`
 }
 
+// SignedEncSolOrder is a signed EncryptedSolutionOrder
+type SignedEncSolOrder struct {
+	EncSolOrder EncryptedSolutionOrder `json:"encsolorder"`
+	Signature   []byte                 `json:"signature"`
+}
+
 // Serialize uses gob encoding to turn the encrypted solution order
 // into bytes.
 func (es *EncryptedSolutionOrder) Serialize() (raw []byte, err error) {
@@ -54,6 +60,49 @@ func (es *EncryptedSolutionOrder) Deserialize(raw []byte) (err error) {
 	// decode the solutionorder in the buffer
 	if err = dec.Decode(es); err != nil {
 		err = fmt.Errorf("Error decoding encryptedsolutionorder: %s", err)
+		return
+	}
+
+	return
+}
+
+// Serialize uses gob encoding to turn the encrypted solution order
+// into bytes.
+func (se *SignedEncSolOrder) Serialize() (raw []byte, err error) {
+	var b bytes.Buffer
+
+	// register SolutionOrder interface
+	gob.Register(SignedEncSolOrder{})
+
+	// create a new encoder writing to the buffer
+	enc := gob.NewEncoder(&b)
+
+	// encode the puzzle in the buffer
+	if err = enc.Encode(se); err != nil {
+		err = fmt.Errorf("Error encoding encsolorder: %s", err)
+		return
+	}
+
+	// Get the bytes from the buffer
+	raw = b.Bytes()
+	return
+}
+
+// Deserialize turns the signed encrypted solution order from bytes
+// into a usable struct.
+func (se *SignedEncSolOrder) Deserialize(raw []byte) (err error) {
+	var b *bytes.Buffer
+	b = bytes.NewBuffer(raw)
+
+	// register SolutionOrder
+	gob.Register(SignedEncSolOrder{})
+
+	// create a new decoder writing to the buffer
+	dec := gob.NewDecoder(b)
+
+	// decode the solutionorder in the buffer
+	if err = dec.Decode(se); err != nil {
+		err = fmt.Errorf("Error decoding encsolorder: %s", err)
 		return
 	}
 

--- a/match/nfrtranscript.go
+++ b/match/nfrtranscript.go
@@ -1,8 +1,16 @@
 package match
 
+// Transcript is the representation of a non front running proof
+// transcript. Puzzled orders are the "batch" and this should be able
+// to be verified quickly.
 type Transcript struct {
-	batchId    AuctionID `json:batchid`
-	batchIdSig []byte    `json:"signature"`
+	batchId          AuctionID                `json:batchid`
+	batchIdSig       []byte                   `json:"signature"`
+	puzzledOrders    []EncryptedSolutionOrder `json:"puzzledorders"`
+	commitment       [32]byte                 `json:"commitment"`
+	commitSig        []byte                   `json:"commitsig"`
+	commResponseSigs [][]byte                 `json:"commresponsesigs"`
+	decryptedOrders  []SolutionOrder          `json:"decryptedorders"`
 	// TODO: finish rest of transcript
 }
 

--- a/match/nfrtranscript.go
+++ b/match/nfrtranscript.go
@@ -1,21 +1,146 @@
 package match
 
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+
+	"github.com/mit-dci/lit/crypto/koblitz"
+	"github.com/mit-dci/opencx/crypto/rsw"
+	"golang.org/x/crypto/sha3"
+)
+
 // Transcript is the representation of a non front running proof
 // transcript. Puzzled orders are the "batch" and this should be able
 // to be verified quickly.
 type Transcript struct {
-	batchId          AuctionID                `json:batchid`
-	batchIdSig       []byte                   `json:"signature"`
-	puzzledOrders    []EncryptedSolutionOrder `json:"puzzledorders"`
-	commitment       [32]byte                 `json:"commitment"`
-	commitSig        []byte                   `json:"commitsig"`
-	commResponseSigs [][]byte                 `json:"commresponsesigs"`
-	decryptedOrders  []SolutionOrder          `json:"decryptedorders"`
-	// TODO: finish rest of transcript
+	batchId       AuctionID                `json:batchid`
+	batchIdSig    []byte                   `json:"signature"`
+	puzzledOrders []EncryptedSolutionOrder `json:"puzzledorders"`
+	commitment    [32]byte                 `json:"commitment"`
+	commitSig     []byte                   `json:"commitsig"`
+	responses     []CommitResponse         `json:"responses"`
 }
+
+// CommitResponse is the commitment response. The sig is the
+// puzzleanswerreveal + the commitment + the commitsig
+type CommitResponse struct {
+	CommResponseSig    []byte        `json:"commresponse"`
+	PuzzleAnswerReveal SolutionOrder `json:"puzzleanswer"`
+}
+
+// TODO: Make a struct for commitment response - p, q, commitment, and
+// a user signature.
 
 // Verify verifies the signatures in the transcript and ensures
 // that the batch was carried out correctly.
-func (tr *Transcript) Verify() (err error) {
+func (tr *Transcript) Verify() (valid bool, err error) {
+	// First verify batch ID
+	hasher := sha3.New256()
+	if _, err = hasher.Write(tr.batchId[:]); err != nil {
+		err = fmt.Errorf("Error writing batch id to hasher: %s", err)
+		return
+	}
+
+	// e is the hash of the batch ID
+	e := hasher.Sum(nil)
+
+	var exchangePubKey *koblitz.PublicKey
+	var batchSigValid bool
+	if exchangePubKey, batchSigValid, err = koblitz.RecoverCompact(koblitz.S256(), tr.batchIdSig, e); err != nil {
+		err = fmt.Errorf("Error recovering pubkey from batch sig: %s", err)
+		return
+	}
+
+	if !batchSigValid {
+		err = fmt.Errorf("Batch id signature invalid: %s", err)
+		return
+	}
+
+	// this is a map from N to the order
+	var pzMap map[*big.Int]EncryptedSolutionOrder = make(map[*big.Int]EncryptedSolutionOrder)
+
+	// TODO: make map for puzzle inclusion (puzzle answer => bool)
+	var bufForCommitment []byte
+	for _, pzOrder := range tr.puzzledOrders {
+		var pzBuf []byte
+		if pzBuf, err = pzOrder.Serialize(); err != nil {
+			err = fmt.Errorf("Error serializing puzzle order for transcript verification: %s", err)
+			return
+		}
+
+		var rswPz rsw.PuzzleRSW
+		if err = rswPz.Deserialize(pzBuf); err != nil {
+			err = fmt.Errorf("Error deserializing puzzle into rsw, ensure that the puzzle sent is valid: %s", err)
+			return
+		}
+
+		pzMap[rswPz.N] = pzOrder
+		bufForCommitment = append(bufForCommitment, pzBuf...)
+	}
+
+	hasher = sha3.New256()
+	if _, err = hasher.Write(bufForCommitment); err != nil {
+		err = fmt.Errorf("Error writing puzzles for commitment to hasher: %s", err)
+		return
+	}
+
+	// hash of the puzzled orders
+	e2 := hasher.Sum(nil)
+
+	var exsig *koblitz.Signature
+	if exsig, err = koblitz.ParseSignature(tr.commitSig, koblitz.S256()); err != nil {
+		err = fmt.Errorf("Error parsing commitment signature: %s", err)
+		return
+	}
+
+	if !exsig.Verify(e2, exchangePubKey) {
+		err = fmt.Errorf("Invalid commitment signature from exchange")
+		return
+	}
+
+	if bytes.Compare(e2, tr.commitment[:]) != 0 {
+		err = fmt.Errorf("Commitment is not equal to hash of orders - invalid transcript")
+		return
+	}
+
+	for _, response := range tr.responses {
+		// comm + sig + answer = e
+		responseHasher := sha3.New256()
+		if _, err = responseHasher.Write(tr.commitment[:]); err != nil {
+			err = fmt.Errorf("Error writing commitment to hasher: %s", err)
+			return
+		}
+		if _, err = responseHasher.Write(tr.commitSig); err != nil {
+			err = fmt.Errorf("Error writing commit sig to hasher: %s", err)
+			return
+		}
+
+		var answerBytes []byte
+		if answerBytes, err = response.PuzzleAnswerReveal.Serialize(); err != nil {
+			err = fmt.Errorf("Error serializing answer: %s", err)
+			return
+		}
+		if _, err = responseHasher.Write(answerBytes); err != nil {
+			err = fmt.Errorf("Error writing answer bytes to hasher: %s", err)
+			return
+		}
+
+		e3 := responseHasher.Sum(nil)
+		var responseSig *koblitz.Signature
+		if responseSig, err = koblitz.ParseSignature(response.CommResponseSig, koblitz.S256()); err != nil {
+			err = fmt.Errorf("Error parsing signature in response: %s", err)
+			return
+		}
+
+		if !responseSig.Verify(e3, exchangePubKey) {
+			err = fmt.Errorf("Invalid user response signature: %s", err)
+			return
+		}
+	}
+
+	// TODO: find a way to connect answers to solution orders, maybe
+	// make a map of puzzle.serialize() => bool and reconstruct puzzle
+	// when you get the solution orders / responses.
 	return
 }

--- a/match/nfrtranscript.go
+++ b/match/nfrtranscript.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mit-dci/lit/crypto/koblitz"
 	"github.com/mit-dci/opencx/crypto/rsw"
+	"github.com/mit-dci/opencx/crypto/timelockencoders"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -20,17 +21,15 @@ type Transcript struct {
 	commitment    [32]byte                 `json:"commitment"`
 	commitSig     []byte                   `json:"commitsig"`
 	responses     []CommitResponse         `json:"responses"`
+	solutions     []AuctionOrder           `json:"solutions"`
 }
 
 // CommitResponse is the commitment response. The sig is the
 // puzzleanswerreveal + the commitment + the commitsig
 type CommitResponse struct {
-	CommResponseSig    []byte        `json:"commresponse"`
+	CommResponseSig    [71]byte      `json:"commresponse"`
 	PuzzleAnswerReveal SolutionOrder `json:"puzzleanswer"`
 }
-
-// TODO: Make a struct for commitment response - p, q, commitment, and
-// a user signature.
 
 // Verify verifies the signatures in the transcript and ensures
 // that the batch was carried out correctly.
@@ -57,9 +56,6 @@ func (tr *Transcript) Verify() (valid bool, err error) {
 		return
 	}
 
-	// this is a map from N to the order
-	var pzMap map[*big.Int]EncryptedSolutionOrder = make(map[*big.Int]EncryptedSolutionOrder)
-
 	// TODO: make map for puzzle inclusion (puzzle answer => bool)
 	var bufForCommitment []byte
 	for _, pzOrder := range tr.puzzledOrders {
@@ -68,14 +64,6 @@ func (tr *Transcript) Verify() (valid bool, err error) {
 			err = fmt.Errorf("Error serializing puzzle order for transcript verification: %s", err)
 			return
 		}
-
-		var rswPz rsw.PuzzleRSW
-		if err = rswPz.Deserialize(pzBuf); err != nil {
-			err = fmt.Errorf("Error deserializing puzzle into rsw, ensure that the puzzle sent is valid: %s", err)
-			return
-		}
-
-		pzMap[rswPz.N] = pzOrder
 		bufForCommitment = append(bufForCommitment, pzBuf...)
 	}
 
@@ -128,7 +116,7 @@ func (tr *Transcript) Verify() (valid bool, err error) {
 
 		e3 := responseHasher.Sum(nil)
 		var responseSig *koblitz.Signature
-		if responseSig, err = koblitz.ParseSignature(response.CommResponseSig, koblitz.S256()); err != nil {
+		if responseSig, err = koblitz.ParseSignature(response.CommResponseSig[:], koblitz.S256()); err != nil {
 			err = fmt.Errorf("Error parsing signature in response: %s", err)
 			return
 		}
@@ -139,8 +127,90 @@ func (tr *Transcript) Verify() (valid bool, err error) {
 		}
 	}
 
-	// TODO: find a way to connect answers to solution orders, maybe
-	// make a map of puzzle.serialize() => bool and reconstruct puzzle
-	// when you get the solution orders / responses.
+	return
+}
+
+// Solve processes the encrypted solution orders and the commitment
+// responses to partition the encrypted orders into those solvable by
+// responses and those that are unsolvable.
+func (tr *Transcript) Solve() (solvedOrders []AuctionOrder, invalidResponses []CommitResponse, err error) {
+	// this is a map from N to the order
+	var pzMap map[*big.Int]EncryptedSolutionOrder = make(map[*big.Int]EncryptedSolutionOrder)
+	for _, pzOrder := range tr.puzzledOrders {
+		var pzBuf []byte
+		if pzBuf, err = pzOrder.Serialize(); err != nil {
+			err = fmt.Errorf("Error serializing puzzle order for transcript verification: %s", err)
+			return
+		}
+
+		var rswPz rsw.PuzzleRSW
+		if err = rswPz.Deserialize(pzBuf); err != nil {
+			err = fmt.Errorf("Error deserializing puzzle into rsw, ensure that the puzzle sent is valid: %s", err)
+			return
+		}
+
+		pzMap[rswPz.N] = pzOrder
+	}
+
+	var solutionMap map[CommitResponse]EncryptedSolutionOrder = make(map[CommitResponse]EncryptedSolutionOrder)
+	var currEnc EncryptedSolutionOrder
+	var ok bool
+	for _, answer := range tr.responses {
+		ok = false
+		tempN := new(big.Int)
+		tempN.Mul(answer.PuzzleAnswerReveal.p, answer.PuzzleAnswerReveal.q)
+		if currEnc, ok = pzMap[tempN]; ok {
+			solutionMap[answer] = currEnc
+		} else {
+			invalidResponses = append(invalidResponses, answer)
+		}
+	}
+
+	for response, encOrder := range solutionMap {
+		var currAuctionOrder AuctionOrder
+		if currAuctionOrder, err = trapdoor(response.PuzzleAnswerReveal.p, response.PuzzleAnswerReveal.q, encOrder); err != nil {
+			err = fmt.Errorf("Error running trapdoor for revealed answer: %s", err)
+			return
+		}
+		solvedOrders = append(solvedOrders, currAuctionOrder)
+	}
+	return
+}
+
+// calculate trapdoor to solve puzzle
+func trapdoor(p, q *big.Int, encOrder EncryptedSolutionOrder) (order AuctionOrder, err error) {
+	// calculate trapdoor e = 2^t mod phi(n) = 2^t mod (p-1)(q-1)
+	two := big.NewInt(2)
+	one := big.NewInt(1)
+	pminusone := new(big.Int).Sub(p, one)
+	qminusone := new(big.Int).Sub(q, one)
+	phi := new(big.Int).Mul(pminusone, qminusone)
+	e := new(big.Int).Exp(two, encOrder.OrderPuzzle.T, phi)
+
+	// calculate b = a^e mod N
+	b := new(big.Int).Exp(encOrder.OrderPuzzle.A, e, encOrder.OrderPuzzle.N)
+
+	// now b xor c_k = k
+	k := new(big.Int).Xor(b, encOrder.OrderPuzzle.CK)
+	kBytes := k.Bytes()
+
+	var key []byte
+	if len(kBytes) <= 16 {
+		key = make([]byte, 16)
+	} else {
+		key = make([]byte, len(kBytes))
+	}
+	copy(key, kBytes)
+
+	var orderBytes []byte
+	if orderBytes, err = timelockencoders.DecryptPuzzleRC5(encOrder.OrderCiphertext, key); err != nil {
+		err = fmt.Errorf("Error decrypting rc5 puzzle from trapdoor key: %s", err)
+		return
+	}
+
+	if err = order.Deserialize(orderBytes); err != nil {
+		err = fmt.Errorf("Error deserializing order for trapdoor into struct: %s", err)
+		return
+	}
 	return
 }

--- a/match/nfrtranscript.go
+++ b/match/nfrtranscript.go
@@ -1,0 +1,13 @@
+package match
+
+type Transcript struct {
+	batchId    AuctionID `json:batchid`
+	batchIdSig []byte    `json:"signature"`
+	// TODO: finish rest of transcript
+}
+
+// Verify verifies the signatures in the transcript and ensures
+// that the batch was carried out correctly.
+func (tr *Transcript) Verify() (err error) {
+	return
+}

--- a/match/nfrtranscript.go
+++ b/match/nfrtranscript.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mit-dci/lit/crypto/koblitz"
 	"github.com/mit-dci/opencx/crypto/rsw"
 	"github.com/mit-dci/opencx/crypto/timelockencoders"
+	"github.com/mit-dci/opencx/logging"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -56,7 +57,6 @@ func (tr *Transcript) Verify() (valid bool, err error) {
 		return
 	}
 
-	// TODO: associate pubkeys with puzzled orders and verify sigs
 	var pubkeyMap map[koblitz.PublicKey]SignedEncSolOrder = make(map[koblitz.PublicKey]SignedEncSolOrder)
 	var bufForCommitment []byte
 	for _, pzOrder := range tr.puzzledOrders {
@@ -164,7 +164,7 @@ func (tr *Transcript) Verify() (valid bool, err error) {
 		}
 
 		// now we get the order and check that it was included. Also
-		// check that p * q = N in puzzle. TODO
+		// check that p * q = N in puzzle, but only log it
 		var ok bool
 		var currEnc SignedEncSolOrder
 		if currEnc, ok = pubkeyMap[*userPubKey]; !ok {
@@ -174,8 +174,7 @@ func (tr *Transcript) Verify() (valid bool, err error) {
 
 		tempN := new(big.Int).Mul(response.PuzzleAnswerReveal.q, response.PuzzleAnswerReveal.p)
 		if tempN.Cmp(currEnc.EncSolOrder.OrderPuzzle.N) != 0 {
-			err = fmt.Errorf("User included incorrect factors in order")
-			return
+			logging.Warnf("User included incorrect factors in order, this order will require some solving")
 		}
 
 	}

--- a/match/nfrtranscript.go
+++ b/match/nfrtranscript.go
@@ -233,6 +233,7 @@ func (tr *Transcript) Solve() (solvedOrders []AuctionOrder, invalidResponses []C
 		}
 	}
 
+	// TODO: parallelize this
 	var currAuctionOrder AuctionOrder
 	for response, encOrder := range solutionMap {
 		if currAuctionOrder, err = trapdoor(response.PuzzleAnswerReveal.P, response.PuzzleAnswerReveal.Q, encOrder); err != nil {

--- a/match/nfrtranscript.go
+++ b/match/nfrtranscript.go
@@ -166,9 +166,15 @@ func (tr *Transcript) Verify() (valid bool, err error) {
 		// now we get the order and check that it was included. Also
 		// check that p * q = N in puzzle. TODO
 		var ok bool
-		// var currEnc SignedEncSolOrder
-		if _, ok = pubkeyMap[*userPubKey]; !ok {
+		var currEnc SignedEncSolOrder
+		if currEnc, ok = pubkeyMap[*userPubKey]; !ok {
 			err = fmt.Errorf("Error, user pubkey not in previous map, so it's a signature without an order")
+			return
+		}
+
+		tempN := new(big.Int).Mul(response.PuzzleAnswerReveal.q, response.PuzzleAnswerReveal.p)
+		if tempN.Cmp(currEnc.EncSolOrder.OrderPuzzle.N) != 0 {
+			err = fmt.Errorf("User included incorrect factors in order")
 			return
 		}
 

--- a/match/nfrtranscript.go
+++ b/match/nfrtranscript.go
@@ -56,7 +56,8 @@ func (tr *Transcript) Verify() (valid bool, err error) {
 		return
 	}
 
-	// TODO: make map for puzzle inclusion (puzzle answer => bool)
+	// TODO: associate pubkeys with puzzled orders and verify sigs
+	var pubkeyMap map[*koblitz.PublicKey]EncryptedSolutionOrder = make(map[*koblitz.PublicKey]EncryptedSolutionOrder)
 	var bufForCommitment []byte
 	for _, pzOrder := range tr.puzzledOrders {
 		var pzBuf []byte
@@ -121,8 +122,10 @@ func (tr *Transcript) Verify() (valid bool, err error) {
 			return
 		}
 
-		if !responseSig.Verify(e3, exchangePubKey) {
-			err = fmt.Errorf("Invalid user response signature: %s", err)
+		var userPubKey *koblitz.PublicKey
+		var userSigValid bool
+		if userPubKey, userSigValid, err = koblitz.RecoverCompact(koblitz.S256(), response.CommResponseSig[:], e3); err != nil {
+			err = fmt.Errorf("Error recovering user pubkey from signature: %s", err)
 			return
 		}
 	}

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -163,6 +163,7 @@ func runBenchTranscriptVerify(b *testing.B, time uint64, orders uint64) {
 	valid, err = emptyTranscript.Verify()
 
 	if !valid {
+		logging.Errorf("Error from benchmark: %s", err)
 		b.Errorf("Empty transcript should have been valid, was invalid: %s", err)
 		return
 	}
@@ -170,15 +171,15 @@ func runBenchTranscriptVerify(b *testing.B, time uint64, orders uint64) {
 }
 
 func BenchmarkValidTranscript10_1(b *testing.B) {
-	runBenchTranscriptVerify(b, 100000, 10)
+	runBenchTranscriptVerify(b, 10000, 10)
 }
 
 func BenchmarkValidTranscript10_2(b *testing.B) {
-	runBenchTranscriptVerify(b, 100000, 100)
+	runBenchTranscriptVerify(b, 10000, 100)
 }
 
 func BenchmarkValidTranscript10_3(b *testing.B) {
-	runBenchTranscriptVerify(b, 100000, 1000)
+	runBenchTranscriptVerify(b, 10000, 1000)
 }
 
 func runValidTranscriptVerify(t *testing.T, time uint64, orders uint64) {

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -9,10 +9,7 @@ func TestEmptyTranscripVerify(t *testing.T) {
 	emptyTranscript := Transcript{}
 
 	var valid bool
-	if valid, err = emptyTranscript.Verify(); err != nil {
-		t.Errorf("Error verifying empty transcript: %s", err)
-		return
-	}
+	valid, err = emptyTranscript.Verify()
 
 	if valid {
 		t.Errorf("Empty transcript should have been invalid, was valid")

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -237,7 +237,7 @@ func runBenchTranscriptVerify(b *testing.B, time uint64, orders uint64) {
 func BenchmarkValidTranscript10K(b *testing.B) {
 	orderAmounts := []uint64{1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1000}
 	for _, amt := range orderAmounts {
-		b.Run(fmt.Sprintf("NumTranscripts10_%d", amt), func(g *testing.B) {
+		b.Run(fmt.Sprintf("NumTranscripts_%d", amt), func(g *testing.B) {
 			runBenchTranscriptVerify(g, 10000, amt)
 		})
 	}
@@ -246,7 +246,7 @@ func BenchmarkValidTranscript10K(b *testing.B) {
 func BenchmarkValidTranscript100K(b *testing.B) {
 	orderAmounts := []uint64{1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1000}
 	for _, amt := range orderAmounts {
-		b.Run(fmt.Sprintf("NumTranscripts10_%d", amt), func(g *testing.B) {
+		b.Run(fmt.Sprintf("NumTranscripts_%d", amt), func(g *testing.B) {
 			runBenchTranscriptVerify(g, 100000, amt)
 		})
 	}
@@ -255,7 +255,7 @@ func BenchmarkValidTranscript100K(b *testing.B) {
 func BenchmarkValidTranscript1M(b *testing.B) {
 	orderAmounts := []uint64{1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1000}
 	for _, amt := range orderAmounts {
-		b.Run(fmt.Sprintf("NumTranscripts10_%d", amt), func(g *testing.B) {
+		b.Run(fmt.Sprintf("NumTranscripts_%d", amt), func(g *testing.B) {
 			runBenchTranscriptVerify(g, 1000000, amt)
 		})
 	}

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -1,10 +1,10 @@
 package match
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/mit-dci/lit/crypto/koblitz"
+	"github.com/mit-dci/opencx/logging"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -25,11 +25,170 @@ func TestEmptyTranscripVerify(t *testing.T) {
 	return
 }
 
-// TestOneOrderValidTranscripVerify creates a transcript with a single
-// order in it and tests that it is valid.
-func TestOneOrderValidTranscripVerify(t *testing.T) {
+func runBenchTranscriptVerify(b *testing.B, time uint64, orders uint64) {
 	var err error
+	if orders == 0 {
+		b.Errorf("Cannot run test with no orders, please setup test correctly")
+		return
+	}
 
+	b.StopTimer()
+	logging.SetLogLevel(3)
+	// create exchange private key
+	var exprivkey *koblitz.PrivateKey
+	if exprivkey, err = koblitz.NewPrivateKey(koblitz.S256()); err != nil {
+		b.Errorf("Error creating exchange private key for signing: %s", err)
+		return
+	}
+
+	// init empty transcript, the id from there is valid
+	emptyTranscript := Transcript{}
+
+	// var idsig *koblitz.Signature
+	// if idsig, err = exprivkey.Sign(hash256(emptyTranscript.batchId[:])); err != nil {
+	// 	err = fmb.Errorf("Error with exchange signing batch id: %s", err)
+	// 	return
+	// }
+	// emptyTranscript.batchIdSig = idsig.Serialize()
+	var batchSig []byte
+	if batchSig, err = koblitz.SignCompact(koblitz.S256(), exprivkey, hash256(emptyTranscript.batchId[:]), false); err != nil {
+		b.Errorf("Error compact signing batch id sig: %s", err)
+		return
+	}
+	emptyTranscript.batchIdSig = make([]byte, len(batchSig))
+	copy(emptyTranscript.batchIdSig, batchSig)
+
+	// This maps private key to solution order so we can respond
+	// correctly later.
+	var privkeyOrderMap map[koblitz.PrivateKey]SolutionOrder = make(map[koblitz.PrivateKey]SolutionOrder)
+	for i := uint64(0); i < orders; i++ {
+		// NOTE: start of user stuff
+		var userPrivKey *koblitz.PrivateKey
+		if userPrivKey, err = koblitz.NewPrivateKey(koblitz.S256()); err != nil {
+			b.Errorf("Error creating new user private key for signing: %s", err)
+			return
+		}
+
+		// First create solution
+		var soln SolutionOrder
+		if soln, err = NewSolutionOrder(2048); err != nil {
+			b.Errorf("Error creating solution order of 2048 bits: %s", err)
+			return
+		}
+		privkeyOrderMap[*userPrivKey] = soln
+
+		// now create encrypted order NOTE: change t to be massive on
+		// larger tests
+		var encOrder EncryptedSolutionOrder
+		if encOrder, err = soln.EncryptSolutionOrder(*origOrder, time); err != nil {
+			b.Errorf("Error encrypting solution order for test: %s", err)
+			return
+		}
+
+		var encOrderBuf []byte
+		if encOrderBuf, err = encOrder.Serialize(); err != nil {
+			b.Errorf("Error serializing encrypted order before signing: %s", err)
+			return
+		}
+
+		var userSigBuf []byte
+		if userSigBuf, err = koblitz.SignCompact(koblitz.S256(), userPrivKey, hash256(encOrderBuf), false); err != nil {
+			b.Errorf("Error signing encrypted order for user: %s", err)
+			return
+		}
+
+		// now that we've created the solution order we add it to the
+		// transcript as being "submitted".
+		signedOrder := SignedEncSolOrder{
+			EncSolOrder: encOrder,
+			Signature:   make([]byte, len(userSigBuf)),
+		}
+
+		// NOTE: this is the most likely point of failure
+		copy(signedOrder.Signature, userSigBuf)
+		emptyTranscript.puzzledOrders = append(emptyTranscript.puzzledOrders, signedOrder)
+	}
+
+	// now that we have a bunch of puzzled orders, we should create a
+	// commitment out of it.
+	var commitmentPreImg []byte
+	for _, encOrder := range emptyTranscript.puzzledOrders {
+		var rawPuzzle []byte
+		if rawPuzzle, err = encOrder.Serialize(); err != nil {
+			b.Errorf("Error serializing submitted order before hashing: %s", err)
+			return
+		}
+		commitmentPreImg = append(commitmentPreImg, rawPuzzle...)
+	}
+	copy(emptyTranscript.commitment[:], hash256(commitmentPreImg))
+	var exchangeCommSig []byte
+	if exchangeCommSig, err = koblitz.SignCompact(koblitz.S256(), exprivkey, emptyTranscript.commitment[:], false); err != nil {
+		b.Errorf("Error with exchange signing the commitment: %s", err)
+		return
+	}
+	emptyTranscript.commitSig = make([]byte, len(exchangeCommSig))
+	copy(emptyTranscript.commitSig, exchangeCommSig)
+
+	// users now create their signatures and reveal solutions
+	for userprivkey, solnorder := range privkeyOrderMap {
+		// because we're running a test we do not check the time -- in
+		// reality you NEED to check the time elapsed.
+		userCommitResponse := CommitResponse{}
+
+		// h(commit + sig + answer) = e
+		var responseBuf []byte
+		responseBuf = append(responseBuf, emptyTranscript.commitment[:]...)
+		responseBuf = append(responseBuf, emptyTranscript.commitSig...)
+		var solnOrderBuf []byte
+		if solnOrderBuf, err = solnorder.Serialize(); err != nil {
+			b.Errorf("Error serializing solution order for response: %s", err)
+			return
+		}
+		responseBuf = append(responseBuf, solnOrderBuf...)
+		var responseSigBuf []byte
+		if responseSigBuf, err = koblitz.SignCompact(koblitz.S256(), &userprivkey, hash256(responseBuf), false); err != nil {
+			b.Errorf("Error for user signing response: %s", err)
+			return
+		}
+		if len(responseSigBuf) != 65 {
+			b.Errorf("Error in test: response signature is not 65 bytes")
+			return
+		}
+		copy(userCommitResponse.CommResponseSig[:], responseSigBuf)
+		userCommitResponse.PuzzleAnswerReveal = solnorder
+	}
+
+	b.StartTimer()
+	var valid bool
+	valid, err = emptyTranscript.Verify()
+
+	if !valid {
+		b.Errorf("Empty transcript should have been valid, was invalid: %s", err)
+		return
+	}
+	return
+}
+
+func BenchmarkValidTranscript10_1(b *testing.B) {
+	runBenchTranscriptVerify(b, 100000, 10)
+}
+
+func BenchmarkValidTranscript10_2(b *testing.B) {
+	runBenchTranscriptVerify(b, 100000, 100)
+}
+
+func BenchmarkValidTranscript10_3(b *testing.B) {
+	runBenchTranscriptVerify(b, 100000, 1000)
+}
+
+func runValidTranscriptVerify(t *testing.T, time uint64, orders uint64) {
+	var err error
+	if orders == 0 {
+		t.Errorf("Cannot run test with no orders, please setup test correctly")
+		return
+	}
+
+	logging.SetLogLevel(3)
 	// create exchange private key
 	var exprivkey *koblitz.PrivateKey
 	if exprivkey, err = koblitz.NewPrivateKey(koblitz.S256()); err != nil {
@@ -40,24 +199,28 @@ func TestOneOrderValidTranscripVerify(t *testing.T) {
 	// init empty transcript, the id from there is valid
 	emptyTranscript := Transcript{}
 
-	var idsig *koblitz.Signature
-	if idsig, err = exprivkey.Sign(hash256(emptyTranscript.batchId[:])); err != nil {
-		err = fmt.Errorf("Error with exchange signing batch id: %s", err)
+	// var idsig *koblitz.Signature
+	// if idsig, err = exprivkey.Sign(hash256(emptyTranscript.batchId[:])); err != nil {
+	// 	err = fmt.Errorf("Error with exchange signing batch id: %s", err)
+	// 	return
+	// }
+	// emptyTranscript.batchIdSig = idsig.Serialize()
+	var batchSig []byte
+	if batchSig, err = koblitz.SignCompact(koblitz.S256(), exprivkey, hash256(emptyTranscript.batchId[:]), false); err != nil {
+		t.Errorf("Error compact signing batch id sig: %s", err)
 		return
 	}
-	emptyTranscript.batchIdSig = idsig.Serialize()
-
-	// set time param
-	time := 100000
+	emptyTranscript.batchIdSig = make([]byte, len(batchSig))
+	copy(emptyTranscript.batchIdSig, batchSig)
 
 	// This maps private key to solution order so we can respond
 	// correctly later.
 	var privkeyOrderMap map[koblitz.PrivateKey]SolutionOrder = make(map[koblitz.PrivateKey]SolutionOrder)
-	for i := 0; i < 1; i++ {
+	for i := uint64(0); i < orders; i++ {
 		// NOTE: start of user stuff
 		var userPrivKey *koblitz.PrivateKey
 		if userPrivKey, err = koblitz.NewPrivateKey(koblitz.S256()); err != nil {
-			err = fmt.Errorf("Error creating new user private key for signing: %s", err)
+			t.Errorf("Error creating new user private key for signing: %s", err)
 			return
 		}
 
@@ -72,21 +235,20 @@ func TestOneOrderValidTranscripVerify(t *testing.T) {
 		// now create encrypted order NOTE: change t to be massive on
 		// larger tests
 		var encOrder EncryptedSolutionOrder
-		if encOrder, err = soln.EncryptSolutionOrder(*origOrder, uint64(time)); err != nil {
+		if encOrder, err = soln.EncryptSolutionOrder(*origOrder, time); err != nil {
 			t.Errorf("Error encrypting solution order for test: %s", err)
 			return
 		}
 
 		var encOrderBuf []byte
 		if encOrderBuf, err = encOrder.Serialize(); err != nil {
-			err = fmt.Errorf("Error serializing encrypted order before signing: %s", err)
+			t.Errorf("Error serializing encrypted order before signing: %s", err)
 			return
 		}
 
-		// now we have to sign the order
-		var solnOrderSig *koblitz.Signature
-		if solnOrderSig, err = userPrivKey.Sign(hash256(encOrderBuf)); err != nil {
-			err = fmt.Errorf("Error signing encrypted order for user: %s", err)
+		var userSigBuf []byte
+		if userSigBuf, err = koblitz.SignCompact(koblitz.S256(), userPrivKey, hash256(encOrderBuf), false); err != nil {
+			t.Errorf("Error signing encrypted order for user: %s", err)
 			return
 		}
 
@@ -94,21 +256,77 @@ func TestOneOrderValidTranscripVerify(t *testing.T) {
 		// transcript as being "submitted".
 		signedOrder := SignedEncSolOrder{
 			EncSolOrder: encOrder,
+			Signature:   make([]byte, len(userSigBuf)),
 		}
 
 		// NOTE: this is the most likely point of failure
-		copy(signedOrder.Signature[:], solnOrderSig.Serialize())
+		copy(signedOrder.Signature, userSigBuf)
 		emptyTranscript.puzzledOrders = append(emptyTranscript.puzzledOrders, signedOrder)
+	}
+
+	// now that we have a bunch of puzzled orders, we should create a
+	// commitment out of it.
+	var commitmentPreImg []byte
+	for _, encOrder := range emptyTranscript.puzzledOrders {
+		var rawPuzzle []byte
+		if rawPuzzle, err = encOrder.Serialize(); err != nil {
+			t.Errorf("Error serializing submitted order before hashing: %s", err)
+			return
+		}
+		commitmentPreImg = append(commitmentPreImg, rawPuzzle...)
+	}
+	copy(emptyTranscript.commitment[:], hash256(commitmentPreImg))
+	var exchangeCommSig []byte
+	if exchangeCommSig, err = koblitz.SignCompact(koblitz.S256(), exprivkey, emptyTranscript.commitment[:], false); err != nil {
+		t.Errorf("Error with exchange signing the commitment: %s", err)
+		return
+	}
+	emptyTranscript.commitSig = make([]byte, len(exchangeCommSig))
+	copy(emptyTranscript.commitSig, exchangeCommSig)
+
+	// users now create their signatures and reveal solutions
+	for userprivkey, solnorder := range privkeyOrderMap {
+		// because we're running a test we do not check the time -- in
+		// reality you NEED to check the time elapsed.
+		userCommitResponse := CommitResponse{}
+
+		// h(commit + sig + answer) = e
+		var responseBuf []byte
+		responseBuf = append(responseBuf, emptyTranscript.commitment[:]...)
+		responseBuf = append(responseBuf, emptyTranscript.commitSig...)
+		var solnOrderBuf []byte
+		if solnOrderBuf, err = solnorder.Serialize(); err != nil {
+			t.Errorf("Error serializing solution order for response: %s", err)
+			return
+		}
+		responseBuf = append(responseBuf, solnOrderBuf...)
+		var responseSigBuf []byte
+		if responseSigBuf, err = koblitz.SignCompact(koblitz.S256(), &userprivkey, hash256(responseBuf), false); err != nil {
+			t.Errorf("Error for user signing response: %s", err)
+			return
+		}
+		if len(responseSigBuf) != 65 {
+			t.Errorf("Error in test: response signature is not 65 bytes")
+			return
+		}
+		copy(userCommitResponse.CommResponseSig[:], responseSigBuf)
+		userCommitResponse.PuzzleAnswerReveal = solnorder
 	}
 
 	var valid bool
 	valid, err = emptyTranscript.Verify()
 
-	if valid {
-		t.Errorf("Empty transcript should have been invalid, was valid")
+	if !valid {
+		t.Errorf("Empty transcript should have been valid, was invalid: %s", err)
 		return
 	}
 	return
+}
+
+// TestOneOrderValidTranscriptVerify creates a transcript with a single
+// order in it and tests that it is valid.
+func TestOneOrderValidTranscriptVerify(t *testing.T) {
+	runValidTranscriptVerify(t, 10000, 1)
 }
 
 // hash256 takes sha3 256-bit hash of some bytes - this ignores

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -4,6 +4,19 @@ import (
 	"testing"
 )
 
-func TestValidTranscripVerify(t *testing.T) {
+func TestEmptyTranscripVerify(t *testing.T) {
+	var err error
+	emptyTranscript := Transcript{}
+
+	var valid bool
+	if valid, err = emptyTranscript.Verify(); err != nil {
+		t.Errorf("Error verifying empty transcript: %s", err)
+		return
+	}
+
+	if valid {
+		t.Errorf("Empty transcript should have been invalid, was valid")
+		return
+	}
 	return
 }

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -1,6 +1,7 @@
 package match
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/mit-dci/lit/crypto/koblitz"
@@ -183,7 +184,9 @@ func runBenchTranscriptVerify(b *testing.B, time uint64, orders uint64) {
 func BenchmarkValidTranscript(b *testing.B) {
 	orderAmounts := []uint64{1, 10, 100}
 	for _, amt := range orderAmounts {
-		runBenchTranscriptVerify(b, 10000, amt)
+		b.Run(fmt.Sprintf("NumTranscripts10_%d", amt), func(g *testing.B) {
+			runBenchTranscriptVerify(g, 10000, amt)
+		})
 	}
 }
 

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -1,7 +1,6 @@
 package match
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/mit-dci/lit/crypto/koblitz"
@@ -26,7 +25,11 @@ func TestEmptyTranscripVerify(t *testing.T) {
 	return
 }
 
+// runBenchTranscriptVerify runs a benchmark which creates orders with
+// a time parameter specified by the user, and creates a valid
+// transcript.
 func runBenchTranscriptVerify(b *testing.B, time uint64, orders uint64) {
+	// TODO: encrypt orders in parallel
 	var err error
 	if orders == 0 {
 		b.Fatalf("Cannot run test with no orders, please setup test correctly")
@@ -110,7 +113,6 @@ func runBenchTranscriptVerify(b *testing.B, time uint64, orders uint64) {
 			Signature:   make([]byte, len(userSigBuf)),
 		}
 
-		// NOTE: this is the most likely point of failure
 		copy(signedOrder.Signature, userSigBuf)
 		transcript.puzzledOrders = append(transcript.puzzledOrders, signedOrder)
 	}
@@ -181,11 +183,7 @@ func runBenchTranscriptVerify(b *testing.B, time uint64, orders uint64) {
 func BenchmarkValidTranscript(b *testing.B) {
 	orderAmounts := []uint64{1, 10, 100}
 	for _, amt := range orderAmounts {
-		b.Run(fmt.Sprintf("BenchValidNFR%d", amt), func(g *testing.B) {
-			for i := 0; i < g.N; i++ {
-				runBenchTranscriptVerify(g, 10000, amt)
-			}
-		})
+		runBenchTranscriptVerify(b, 10000, amt)
 	}
 }
 

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -1,0 +1,9 @@
+package match
+
+import (
+	"testing"
+)
+
+func TestValidTranscripVerify(t *testing.T) {
+	return
+}

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -89,8 +89,8 @@ func runBenchTranscriptVerify(b *testing.B, time uint64, orders uint64) {
 		solnBuf[i].Q = new(big.Int)
 		go func(j int) {
 			var soln SolutionOrder
-			if soln, errBuf[j] = NewSolutionOrder(2048); errBuf[j] != nil {
-				errBuf[j] = fmt.Errorf("Error creating solution order of 2048 bits: %s", errBuf[j])
+			if soln, errBuf[j] = NewSolutionOrder(1024); errBuf[j] != nil {
+				errBuf[j] = fmt.Errorf("Error creating solution order of 1024 bits: %s", errBuf[j])
 				wg.Done()
 				return
 			}
@@ -122,8 +122,7 @@ func runBenchTranscriptVerify(b *testing.B, time uint64, orders uint64) {
 
 		privkeyOrderMap[*userPrivKey] = soln
 
-		// now create encrypted order NOTE: change t to be massive on
-		// larger tests
+		// now create encrypted order
 		var encOrder EncryptedSolutionOrder
 		if encOrder, err = soln.EncryptSolutionOrder(*origOrder, time); err != nil {
 			b.Fatalf("Error encrypting solution order for test: %s", err)
@@ -234,29 +233,41 @@ func runBenchTranscriptVerify(b *testing.B, time uint64, orders uint64) {
 	return
 }
 
-func BenchmarkValidTranscript10K(b *testing.B) {
-	orderAmounts := []uint64{1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1000}
-	for _, amt := range orderAmounts {
-		b.Run(fmt.Sprintf("NumTranscripts_%d", amt), func(g *testing.B) {
-			runBenchTranscriptVerify(g, 10000, amt)
-		})
-	}
-}
+// TODO: Create benchmark which re-uses SolutionOrders, verify
+// completely in parallel
 
-func BenchmarkValidTranscript100K(b *testing.B) {
-	orderAmounts := []uint64{1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1000}
+// func BenchmarkValidTranscript10K(b *testing.B) {
+// 	orderAmounts := []uint64{1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1000}
+// 	for _, amt := range orderAmounts {
+// 		b.Run(fmt.Sprintf("NumTranscripts_%d", amt), func(g *testing.B) {
+// 			runBenchTranscriptVerify(g, 10000, amt)
+// 		})
+// 	}
+// }
+
+func BenchmarkValidTranscript100M(b *testing.B) {
+	orderAmounts := []uint64{1, 10, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000}
 	for _, amt := range orderAmounts {
 		b.Run(fmt.Sprintf("NumTranscripts_%d", amt), func(g *testing.B) {
-			runBenchTranscriptVerify(g, 100000, amt)
+			runBenchTranscriptVerify(g, 100000000, amt)
 		})
 	}
 }
 
 func BenchmarkValidTranscript1M(b *testing.B) {
-	orderAmounts := []uint64{1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1000}
+	orderAmounts := []uint64{1, 10, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000}
 	for _, amt := range orderAmounts {
 		b.Run(fmt.Sprintf("NumTranscripts_%d", amt), func(g *testing.B) {
 			runBenchTranscriptVerify(g, 1000000, amt)
+		})
+	}
+}
+
+func BenchmarkValidTranscript10K(b *testing.B) {
+	orderAmounts := []uint64{1, 10, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000}
+	for _, amt := range orderAmounts {
+		b.Run(fmt.Sprintf("NumTranscripts_%d", amt), func(g *testing.B) {
+			runBenchTranscriptVerify(g, 10000, amt)
 		})
 	}
 }
@@ -322,8 +333,8 @@ func runValidTranscriptVerify(t *testing.T, time uint64, orders uint64) {
 
 		// First create solution
 		var soln SolutionOrder
-		if soln, err = NewSolutionOrder(2048); err != nil {
-			t.Errorf("Error creating solution order of 2048 bits: %s", err)
+		if soln, err = NewSolutionOrder(1024); err != nil {
+			t.Errorf("Error creating solution order of 1024 bits: %s", err)
 			return
 		}
 		privkeyOrderMap[*userPrivKey] = soln

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -221,6 +221,16 @@ func runBenchTranscriptVerify(b *testing.B, time uint64, orders uint64) {
 		b.Fatalf("Empty transcript should have been valid, was invalid: %s", err)
 		return
 	}
+
+	var fullTScript []byte
+	if fullTScript, err = transcript.Serialize(); err != nil {
+		b.Fatalf("Error serializing transcript: %s", err)
+		return
+	}
+
+	b.Logf("Transcript bytes: %d", len(fullTScript))
+	b.Logf("Orders processed: %d", orders)
+	b.Logf("Transcript bytes per user: %f", float(len(fullTScript))/float(orders))
 	return
 }
 
@@ -606,6 +616,16 @@ func runBenchTranscriptSolve(b *testing.B, time uint64, orders uint64) {
 		b.Fatalf("Exchange could not solve all orders, it should have been able to: %s", err)
 		return
 	}
+
+	var fullTScript []byte
+	if fullTScript, err = transcript.Serialize(); err != nil {
+		b.Fatalf("Error serializing transcript: %s", err)
+		return
+	}
+
+	b.Logf("Transcript bytes: %d", len(fullTScript))
+	b.Logf("Orders processed: %d", orders)
+	b.Logf("Transcript bytes per user: %f", float(len(fullTScript))/float(orders))
 	return
 }
 

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -1,9 +1,15 @@
 package match
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/mit-dci/lit/crypto/koblitz"
+	"golang.org/x/crypto/sha3"
 )
 
+// TestEmptyTranscripVerify tests an empty transcript and makes sure
+// that it is not valid
 func TestEmptyTranscripVerify(t *testing.T) {
 	var err error
 	emptyTranscript := Transcript{}
@@ -15,5 +21,65 @@ func TestEmptyTranscripVerify(t *testing.T) {
 		t.Errorf("Empty transcript should have been invalid, was valid")
 		return
 	}
+	return
+}
+
+// TestOneOrderValidTranscripVerify creates a transcript with a single
+// order in it and tests that it is valid.
+func TestOneOrderValidTranscripVerify(t *testing.T) {
+	var err error
+
+	// create exchange private key
+	var exprivkey *koblitz.PrivateKey
+	if exprivkey, err = koblitz.NewPrivateKey(koblitz.S256()); err != nil {
+		t.Errorf("Error creating exchange private key for signing: %s", err)
+		return
+	}
+
+	// init empty transcript, the id from there is valid
+	emptyTranscript := Transcript{}
+
+	var idsig *koblitz.Signature
+	if idsig, err = exprivkey.Sign(hash256(emptyTranscript.batchId[:])); err != nil {
+		err = fmt.Errorf("Error with exchange signing batch id: %s", err)
+		return
+	}
+	emptyTranscript.batchIdSig = idsig.Serialize()
+
+	// set time param
+	time := 100000
+
+	// NOTE: start of user stuff
+	// First create solution
+	var soln SolutionOrder
+	if soln, err = NewSolutionOrder(2048); err != nil {
+		t.Errorf("Error creating solution order of 2048 bits: %s", err)
+		return
+	}
+
+	// now create encrypted order NOTE: change t to be massive on
+	// larger tests
+	var encOrder EncryptedSolutionOrder
+	if encOrder, err = soln.EncryptSolutionOrder(origOrder, time); err != nil {
+		t.Errorf("Error encrypting solution order for test: %s", err)
+		return
+	}
+
+	var valid bool
+	valid, err = emptyTranscript.Verify()
+
+	if valid {
+		t.Errorf("Empty transcript should have been invalid, was valid")
+		return
+	}
+	return
+}
+
+// hash256 takes sha3 256-bit hash of some bytes - this ignores
+// errors.
+func hash256(preimage []byte) (h []byte) {
+	hashingAlgo := sha3.New256()
+	hashingAlgo.Write(preimage)
+	h = hashingAlgo.Sum(nil)
 	return
 }

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -53,7 +53,7 @@ func TestOneOrderValidTranscripVerify(t *testing.T) {
 	// This maps private key to solution order so we can respond
 	// correctly later.
 	var privkeyOrderMap map[koblitz.PrivateKey]SolutionOrder = make(map[koblitz.PrivateKey]SolutionOrder)
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 1; i++ {
 		// NOTE: start of user stuff
 		var userPrivKey *koblitz.PrivateKey
 		if userPrivKey, err = koblitz.NewPrivateKey(koblitz.S256()); err != nil {

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -246,7 +246,7 @@ func runBenchTranscriptVerify(b *testing.B, time uint64, orders uint64) {
 // }
 
 func BenchmarkValidTranscript100M(b *testing.B) {
-	orderAmounts := []uint64{1, 10, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000}
+	orderAmounts := []uint64{1, 10, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000, 1500, 2000}
 	for _, amt := range orderAmounts {
 		b.Run(fmt.Sprintf("NumTranscripts_%d", amt), func(g *testing.B) {
 			runBenchTranscriptVerify(g, 100000000, amt)
@@ -255,7 +255,7 @@ func BenchmarkValidTranscript100M(b *testing.B) {
 }
 
 func BenchmarkValidTranscript1M(b *testing.B) {
-	orderAmounts := []uint64{1, 10, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000}
+	orderAmounts := []uint64{1, 10, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000, 1500, 2000}
 	for _, amt := range orderAmounts {
 		b.Run(fmt.Sprintf("NumTranscripts_%d", amt), func(g *testing.B) {
 			runBenchTranscriptVerify(g, 1000000, amt)
@@ -264,7 +264,7 @@ func BenchmarkValidTranscript1M(b *testing.B) {
 }
 
 func BenchmarkValidTranscript10K(b *testing.B) {
-	orderAmounts := []uint64{1, 10, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000}
+	orderAmounts := []uint64{1, 10, 20, 40, 60, 80, 100, 200, 400, 600, 800, 1000, 1500, 2000}
 	for _, amt := range orderAmounts {
 		b.Run(fmt.Sprintf("NumTranscripts_%d", amt), func(g *testing.B) {
 			runBenchTranscriptVerify(g, 10000, amt)

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -234,11 +234,29 @@ func runBenchTranscriptVerify(b *testing.B, time uint64, orders uint64) {
 	return
 }
 
-func BenchmarkValidTranscript(b *testing.B) {
-	orderAmounts := []uint64{1, 10, 100, 1000}
+func BenchmarkValidTranscript10K(b *testing.B) {
+	orderAmounts := []uint64{1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1000}
 	for _, amt := range orderAmounts {
 		b.Run(fmt.Sprintf("NumTranscripts10_%d", amt), func(g *testing.B) {
 			runBenchTranscriptVerify(g, 10000, amt)
+		})
+	}
+}
+
+func BenchmarkValidTranscript100K(b *testing.B) {
+	orderAmounts := []uint64{1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1000}
+	for _, amt := range orderAmounts {
+		b.Run(fmt.Sprintf("NumTranscripts10_%d", amt), func(g *testing.B) {
+			runBenchTranscriptVerify(g, 100000, amt)
+		})
+	}
+}
+
+func BenchmarkValidTranscript1M(b *testing.B) {
+	orderAmounts := []uint64{1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1000}
+	for _, amt := range orderAmounts {
+		b.Run(fmt.Sprintf("NumTranscripts10_%d", amt), func(g *testing.B) {
+			runBenchTranscriptVerify(g, 1000000, amt)
 		})
 	}
 }

--- a/match/nfrtranscript_test.go
+++ b/match/nfrtranscript_test.go
@@ -183,7 +183,7 @@ func BenchmarkValidTranscript(b *testing.B) {
 	for _, amt := range orderAmounts {
 		b.Run(fmt.Sprintf("BenchValidNFR%d", amt), func(g *testing.B) {
 			for i := 0; i < g.N; i++ {
-				runBenchTranscriptVerify(b, 10000, amt)
+				runBenchTranscriptVerify(g, 10000, amt)
 			}
 		})
 	}

--- a/match/puzsolorder.go
+++ b/match/puzsolorder.go
@@ -17,6 +17,9 @@ type SolutionOrder struct {
 	q         *big.Int     `json:"q"`
 }
 
+// NewSolutionOrderFromOrder creates a new SolutionOrder from an
+// already existing AuctionOrder, with a specified number of bits for
+// an rsa key.
 func NewSolutionOrderFromOrder(aucOrder *AuctionOrder, rsaKeyBits uint64) (solOrder SolutionOrder, err error) {
 	if aucOrder == nil {
 		err = fmt.Errorf("Cannot create solution order from nil auction order")

--- a/match/puzsolorder.go
+++ b/match/puzsolorder.go
@@ -1,0 +1,42 @@
+package match
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"math/big"
+)
+
+// SolutionOrder is an order and modulus that are together.
+// This includes an order, and the puzzle modulus factors.
+type SolutionOrder struct {
+	userOrder AuctionOrder `json:"userorder"`
+	p         *big.Int     `json:"p"`
+	q         *big.Int     `json:"q"`
+}
+
+func NewSolutionOrderFromOrder(aucOrder *AuctionOrder) (solOrder SolutionOrder, err error) {
+	if aucOrder == nil {
+		err = fmt.Errorf("Cannot create solution order from nil auction order")
+		return
+	}
+
+	// generate primes p and q
+	var rsaPrivKey *rsa.PrivateKey
+	if rsaPrivKey, err = rsa.GenerateMultiPrimeKey(rand.Reader, 2, tl.rsaKeyBits); err != nil {
+		err = fmt.Errorf("Could not generate primes for RSA: %s", err)
+		return
+	}
+	if len(rsaPrivKey.Primes) != 2 {
+		err = fmt.Errorf("For some reason the RSA Privkey has != 2 primes, this should not be the case for RSW, we only need p and q")
+		return
+	}
+
+	// finally set p, q, and the auction order.
+	solOrder.p = new(big.Int).SetBytes(rsaPrivKey.Primes[0].Bytes())
+	solOrder.q = new(big.Int).SetBytes(rsaPrivKey.Primes[1].Bytes())
+	solOrder.userOrder = *AuctionOrder
+	return
+}
+
+// TODO: allow for solution order to be turned into puzzle order

--- a/match/puzsolorder.go
+++ b/match/puzsolorder.go
@@ -8,18 +8,8 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/mit-dci/opencx/crypto"
 	"github.com/mit-dci/opencx/crypto/timelockencoders"
 )
-
-// EncryptedSolutionOrder represents an encrypted Solution Order, so a
-// ciphertext and a puzzle solution that is a key, and an intended auction.
-type EncryptedSolutionOrder struct {
-	OrderCiphertext []byte        `json:"orderciphertext"`
-	OrderPuzzle     crypto.Puzzle `json:"orderpuzzle"`
-	IntendedAuction AuctionID     `json:"intendedauction"`
-	IntendedPair    Pair          `json:"intendedpair"`
-}
 
 // SolutionOrder is an order and modulus that are together.
 // This includes an order, and the puzzle modulus factors.

--- a/match/puzsolorder.go
+++ b/match/puzsolorder.go
@@ -14,8 +14,8 @@ import (
 // SolutionOrder is an order and modulus that are together.
 // This includes an order, and the puzzle modulus factors.
 type SolutionOrder struct {
-	p *big.Int `json:"p"`
-	q *big.Int `json:"q"`
+	P *big.Int `json:"p"`
+	Q *big.Int `json:"q"`
 }
 
 // NewSolutionOrder creates a new SolutionOrder from an already
@@ -36,8 +36,8 @@ func NewSolutionOrder(rsaKeyBits uint64) (solOrder SolutionOrder, err error) {
 	}
 
 	// finally set p, q, and the auction order.
-	solOrder.p = new(big.Int).SetBytes(rsaPrivKey.Primes[0].Bytes())
-	solOrder.q = new(big.Int).SetBytes(rsaPrivKey.Primes[1].Bytes())
+	solOrder.P = new(big.Int).SetBytes(rsaPrivKey.Primes[0].Bytes())
+	solOrder.Q = new(big.Int).SetBytes(rsaPrivKey.Primes[1].Bytes())
 	return
 }
 
@@ -46,7 +46,7 @@ func NewSolutionOrder(rsaKeyBits uint64) (solOrder SolutionOrder, err error) {
 func (so *SolutionOrder) EncryptSolutionOrder(auctionOrder AuctionOrder, t uint64) (encSolOrder EncryptedSolutionOrder, err error) {
 	// Try serializing the solution order
 	var rawSolOrder []byte = auctionOrder.Serialize()
-	if encSolOrder.OrderCiphertext, encSolOrder.OrderPuzzle, err = timelockencoders.CreateRC5RSWPuzzleWithPrimes(uint64(2), t, rawSolOrder, so.p, so.q); err != nil {
+	if encSolOrder.OrderCiphertext, encSolOrder.OrderPuzzle, err = timelockencoders.CreateRC5RSWPuzzleWithPrimes(uint64(2), t, rawSolOrder, so.P, so.Q); err != nil {
 		err = fmt.Errorf("Error creating puzzle from auction order: %s", err)
 		return
 	}

--- a/match/puzsolorder.go
+++ b/match/puzsolorder.go
@@ -18,10 +18,10 @@ type SolutionOrder struct {
 	q *big.Int `json:"q"`
 }
 
-// NewSolutionOrderFromOrder creates a new SolutionOrder from an
-// already existing AuctionOrder, with a specified number of bits for
-// an rsa key.
-func NewSolutionOrderFromOrder(rsaKeyBits uint64) (solOrder SolutionOrder, err error) {
+// NewSolutionOrder creates a new SolutionOrder from an already
+// existing AuctionOrder, with a specified number of bits for an rsa
+// key.
+func NewSolutionOrder(rsaKeyBits uint64) (solOrder SolutionOrder, err error) {
 	rsaKeyBitsInt := int(rsaKeyBits)
 
 	// generate primes p and q

--- a/match/puzsolorder.go
+++ b/match/puzsolorder.go
@@ -46,11 +46,6 @@ func NewSolutionOrderFromOrder(rsaKeyBits uint64) (solOrder SolutionOrder, err e
 func (so *SolutionOrder) EncryptSolutionOrder(auctionOrder AuctionOrder, t uint64) (encSolOrder EncryptedSolutionOrder, err error) {
 	// Try serializing the solution order
 	var rawSolOrder []byte = auctionOrder.Serialize()
-	// if rawSolOrder, err = auctionOrder.Serialize(); err != nil {
-	// 	err = fmt.Errorf("Error serializing solution order for encryption: %s", err)
-	// 	return
-	// }
-
 	if encSolOrder.OrderCiphertext, encSolOrder.OrderPuzzle, err = timelockencoders.CreateRC5RSWPuzzleWithPrimes(uint64(2), t, rawSolOrder, so.p, so.q); err != nil {
 		err = fmt.Errorf("Error creating puzzle from auction order: %s", err)
 		return


### PR DESCRIPTION
This PR adds a NFR transcript and verification for the transcript.
A lot of it runs in parallel, for example key generation for the timelock puzzles, and it might help to hard-code some big numbers that are keys in order to lower the overhead when running large benchmarks.

This fixes #35.